### PR TITLE
style: Add `conventional-pre-commit` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,9 @@ repos:
     rev: v3.15.0
     hooks:
     -   id: pyupgrade
+-   repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.0.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: []


### PR DESCRIPTION
This pre-commit hook checks commit messages for consistency with https://www.conventionalcommits.org/en/v1.0.0/