### PR TITLE
Remove `openai` dependency by using `requests` library directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ IMAGE := anki-convo
 WIN_APPDATA := $(shell wslpath "$$(wslvar APPDATA)")
 ANKI_ADDON_PATH := ${WIN_APPDATA}/Anki2/addons21/9999999999
 SITE_PACKAGES_PATH := ./.direnv/anki-convo/lib/python3.9/site-packages
-REQUIREMENTS := yaml openai aiohttp aiosignal async_timeout charset_normalizer frozenlist multidict yarl tqdm dotenv
+REQUIREMENTS := yaml charset_normalizer dotenv
 K8S_ENV?=dev
 
 ankisync:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 anki
 aqt[qt6]
-openai<1.0
 python-dotenv
 fastapi
 fastapi-versionizer

--- a/src/anki_convo/__init__.py
+++ b/src/anki_convo/__init__.py
@@ -7,7 +7,6 @@ from .__about__ import NAME, __version__  # noqa: F401
 import os
 
 from .env import load_env
-from .openai import init_openai
 from .hooks import init_hooks
 from .logging import setup_logging, get_logger
 
@@ -19,7 +18,6 @@ logger = get_logger(__name__)
 def init_package():
     logger.info("Initializing package")
     load_env()
-    init_openai()
 
 
 def init_addon():  # pragma: no cover

--- a/src/anki_convo/llms/openai.py
+++ b/src/anki_convo/llms/openai.py
@@ -1,8 +1,9 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
-import openai
+import requests
 
+from ..openai import OPENAI_CHAT_COMPLETIONS_URL, get_openai_api_key
 from .base import LLM
 
 
@@ -11,17 +12,24 @@ class OpenAI(LLM):
     """LLM that uses OpenAI's API."""
 
     model: str = "gpt-3.5-turbo"
+    api_key: str = field(repr=False, compare=False, default_factory=get_openai_api_key)
 
-    def _call(self, prompt: str, **kwargs: Any) -> str:
+    def _call(self, prompt: str, **kwargs: Any) -> str:  # noqa: ARG002
         """Run the LLM on the given prompt and input."""
+        url = OPENAI_CHAT_COMPLETIONS_URL
         messages = [{"role": "user", "content": prompt}]
+        json = {"model": self.model, "messages": messages}
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+        }
+
+        response = requests.post(url, json=json, headers=headers, timeout=30)
         try:
-            completion = openai.ChatCompletion.create(
-                model=self.model,
-                messages=messages,
-                **kwargs,
-            )
-        except openai.error.OpenAIError as e:
+            response.raise_for_status()
+        except requests.HTTPError as e:
             self._raise(e)
 
-        return completion.choices[0].message.content
+        completion = response.json()
+        content = completion["choices"][0]["message"]["content"]
+        return content

--- a/src/anki_convo/openai.py
+++ b/src/anki_convo/openai.py
@@ -1,7 +1,9 @@
 import os
 
-import openai
+
+def get_openai_api_key():
+    """Get the OpenAI API key from the environment."""
+    return os.getenv("OPENAI_API_KEY")
 
 
-def init_openai():
-    openai.api_key = os.getenv("OPENAI_API_KEY")
+OPENAI_CHAT_COMPLETIONS_URL = "https://api.openai.com/v1/chat/completions"

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,10 +1,26 @@
 from functools import lru_cache
 from typing import Callable, Mapping, TypeVar
 
+import requests
+
 from anki_convo.card import TranslationCard
 from anki_convo.card_gen import CardGeneratorConfig
 
 T_co = TypeVar("T_co", covariant=True)
+
+
+class MockResponse:
+    def __init__(self, json, status_code=200):
+        self._json = json
+        self.status_code = status_code
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code != 200:
+            message = f"Mock error: {self.status_code}"
+            raise requests.HTTPError(message)
 
 
 class CountingCardGenerator:


### PR DESCRIPTION
Version 1 of `openai` introduced a dependency on `pydantic` which we don't want in the current add-on. We want to keep the dependencies light, to reduce reliance on copying dependency code into the eventual add-on zipfile (since Anki doesn't have a full-fledged dependency management system for the add-ons yet).